### PR TITLE
feat(reader): persist scroll position

### DIFF
--- a/lib/screens/reader/reader_screen.dart
+++ b/lib/screens/reader/reader_screen.dart
@@ -354,6 +354,7 @@ class _ReaderScreenState extends State<ReaderScreen> {
                   child: ChapterDisplay(
                     chapterContent: currentChapter?.content,
                     readerSettings: appState.readerSettings,
+                    chapterId: currentChapter!.id,
                   ),
                 ),
                 ChapterNavigation(


### PR DESCRIPTION
When leaving the chapter and returning to the reading position, the reading position must be maintained. Fixes #49
- Added scroll position saving/loading
- Uses SharedPreferences for storage
- Implemented JavaScript injection
- Improved user experience
- Handles multiple chapters